### PR TITLE
Avoid "need 0.0pt more!" warnings

### DIFF
--- a/tabularray.sty
+++ b/tabularray.sty
@@ -2767,7 +2767,7 @@
 \prop_new:N \l__column_computed_width_prop
 
 \msg_new:nnn { tabularray } { table-width-too-small }
-  { Table ~ width ~ is ~ too ~ small, need ~ #1 ~ more! }
+  { Table ~ width ~ is ~ too ~ small, ~ need ~ #1 ~ more! }
 
 \cs_new_protected:Npn \__tblr_compute_extendable_column_width:
   {

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -2772,7 +2772,7 @@
 \cs_new_protected:Npn \__tblr_compute_extendable_column_width:
   {
     \__tblr_collect_extendable_column_width:
-    \dim_compare:nNnTF { \l__column_target_dim } > { 0pt }
+    \dim_compare:nTF { \l__column_target_dim  >=  0pt }
       {
         \prop_if_empty:NF \l__column_coefficient_prop
           { \__tblr_adjust_extendable_column_width: }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -2772,14 +2772,14 @@
 \cs_new_protected:Npn \__tblr_compute_extendable_column_width:
   {
     \__tblr_collect_extendable_column_width:
-    \dim_compare:nTF { \l__column_target_dim  >=  0pt }
-      {
-        \prop_if_empty:NF \l__column_coefficient_prop
-          { \__tblr_adjust_extendable_column_width: }
-      }
+    \dim_compare:nNnTF { \l__column_target_dim } < { 0pt }
       {
         \msg_warning:nnx { tabularray } { table-width-too-small }
           { \dim_abs:n { \l__column_target_dim } }
+      }
+      {
+        \prop_if_empty:NF \l__column_coefficient_prop
+          { \__tblr_adjust_extendable_column_width: }
       }
   }
 


### PR DESCRIPTION
This PR tries to avoid the unnecessary warning:

>Package tabularray Warning : Table width is too small,need 0.0pt more !"

which appears for example in the following case:
```latex
\documentclass{article}
\usepackage{tabularray}
\begin{document}
\noindent%
\begin{tblr}{colspec={p{\linewidth-2\rulewidth-2\tabcolsep}},vlines}
  Foo
\end{tblr}
\end{document}
```
While I was at it, I added a missing space.