### PR TITLE
Make `longtblr` compatible with `\nameref`

### DIFF
--- a/tabularray.sty
+++ b/tabularray.sty
@@ -5338,6 +5338,7 @@
       \l__tblr_table_lastfoot_box  { \UseTblrTemplate { lastfoot } { default } }
   }
 
+\makeatletter
 \cs_new_protected:Npn \__tblr_build_table_label_entry:
   {
     \tl_set:Nx \l_tmpa_tl { \InsertTblrText { label } }
@@ -5347,6 +5348,15 @@
         \SetTblrTemplate { caption-sep }{ empty }
       }
       {
+        \cs_if_exist:NT { \@currentlabelname }
+          {
+            \tl_set:Nx \l_tmpb_tl { \InsertTblrText { entry } }
+            \tl_if_empty:NT \l_tmpb_tl
+              { \tl_set:NV \l_tmpb_tl { \InsertTblrText { caption } } }
+            \exp_args:NV \GetTitleString \l_tmpb_tl
+            \tl_gset:Nx \@currentlabelname \GetTitleStringResult
+          }
+
         \refstepcounter { table }
         \tl_if_empty:NF \l_tmpa_tl { \exp_args:NV \label \l_tmpa_tl }
       }
@@ -5354,6 +5364,7 @@
     \tl_if_eq:NnF \l_tmpb_tl { none }
       { \UseTblrTemplate { caption-lot } { default } }
   }
+\makeatother
 
 \cs_new_protected:Npn \__tblr_build_table_head_aux:Nn #1 #2
   {

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -5341,27 +5341,27 @@
 \cs_new_protected:Npn \__tblr_build_table_label_entry:
   {
     \tl_set:Nx \l_tmpa_tl { \InsertTblrText { label } }
+    \tl_set:Nx \l_tmpb_tl { \InsertTblrText { entry } }
+    \tl_if_eq:NnF \l_tmpb_tl { none }
+      {
+        \UseTblrTemplate { caption-lot }{ default }
+      }
     \tl_if_eq:NnTF \l_tmpa_tl { none }
       {
         \SetTblrTemplate { caption-tag }{ empty }
         \SetTblrTemplate { caption-sep }{ empty }
       }
       {
-        \cs_if_exist:NT { \@currentlabelname }
+        \cs_if_exist:NT \@currentlabelname
           {
-            \tl_set:Nx \l_tmpb_tl { \InsertTblrText { entry } }
             \tl_if_empty:NT \l_tmpb_tl
-              { \tl_set:NV \l_tmpb_tl { \InsertTblrText { caption } } }
+              { \tl_set:Nx \l_tmpb_tl { \InsertTblrText { caption } } }
             \exp_args:NV \GetTitleString \l_tmpb_tl
-            \tl_gset:Nx \@currentlabelname \GetTitleStringResult
+            \tl_set_eq:NN \@currentlabelname \GetTitleStringResult
           }
-
         \refstepcounter { table }
         \tl_if_empty:NF \l_tmpa_tl { \exp_args:NV \label \l_tmpa_tl }
       }
-    \tl_set:Nx \l_tmpb_tl { \InsertTblrText { entry } }
-    \tl_if_eq:NnF \l_tmpb_tl { none }
-      { \UseTblrTemplate { caption-lot } { default } }
   }
 
 \cs_new_protected:Npn \__tblr_build_table_head_aux:Nn #1 #2

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -5338,7 +5338,6 @@
       \l__tblr_table_lastfoot_box  { \UseTblrTemplate { lastfoot } { default } }
   }
 
-\makeatletter
 \cs_new_protected:Npn \__tblr_build_table_label_entry:
   {
     \tl_set:Nx \l_tmpa_tl { \InsertTblrText { label } }
@@ -5364,7 +5363,6 @@
     \tl_if_eq:NnF \l_tmpb_tl { none }
       { \UseTblrTemplate { caption-lot } { default } }
   }
-\makeatother
 
 \cs_new_protected:Npn \__tblr_build_table_head_aux:Nn #1 #2
   {


### PR DESCRIPTION
This makes `longtblr` captions compatible with `\nameref`. Without this change, `\nameref` on a `longtblr` is simply empty. 

It checks if `\@currentlabelname` is defined (so `hyperref` package is loaded, hopefully), and defines it using the `entry` if it exists else using the `caption`. 

MWE provided here. 

```
\documentclass{article}
\usepackage{tabularray}

\makeatletter
\ExplSyntaxOn
\cs_set_protected:Npn \__tblr_build_table_label_entry:
  {
    \tl_set:Nx \l_tmpa_tl { \InsertTblrText { label } }
    \tl_if_eq:NnTF \l_tmpa_tl { none }
      {
        \SetTblrTemplate { caption-tag }{ empty }
        \SetTblrTemplate { caption-sep }{ empty }
      }
      {
        \cs_if_exist:NT { \@currentlabelname }
          {
            \tl_set:Nx \l_tmpb_tl { \InsertTblrText { entry } }
            \tl_if_empty:NT \l_tmpb_tl
              { \tl_set:NV \l_tmpb_tl { \InsertTblrText { caption } } }
            \exp_args:NV \GetTitleString \l_tmpb_tl
            \tl_gset:Nx \@currentlabelname \GetTitleStringResult
          }

        \refstepcounter { table }
        \tl_if_empty:NF \l_tmpa_tl { \exp_args:NV \label \l_tmpa_tl }
      }
    \tl_set:Nx \l_tmpb_tl { \InsertTblrText { entry } }
    \tl_if_eq:NnF \l_tmpb_tl { none }
      { \UseTblrTemplate { caption-lot } { default } }
  }
\ExplSyntaxOff
\makeatother

\usepackage{hyperref}

\begin{document}

Refer to \autoref{tblr:mylongtblr}: \nameref{tblr:mylongtblr}.

\begin{longtblr}[
    caption = {My longtblr long caption},
    entry = {My longtblr entry},
    label = {tblr:mylongtblr},
]{
    colspec = { Q[10em,c] Q[10em,c] },
}
A & B \\
C & D \\
\end{longtblr}

\end{document}
```