### PR TITLE
Improve docs for `booktabs` lib

### DIFF
--- a/manual/manual-1.tex
+++ b/manual/manual-1.tex
@@ -62,7 +62,7 @@ If you don't like it, you could use \verb!\SetTblrInner! command:
  Iota    & Kappa & Lambda & Mu    \\
 \hline
 \end{tblr}
-\end{demohigh} 
+\end{demohigh}
 
 But in many cases, this \verb!rowsep! is useful:
 
@@ -101,7 +101,7 @@ just enclose the cell text with braces and use \verb!\\! to break lines:
  {L \\ Left} & {C \\ Cent \\ Center} & R \\
 \hline
 \end{tblr}
-\end{demohigh} 
+\end{demohigh}
 
 \section{Cell Alignment}
 
@@ -117,7 +117,7 @@ other columns are defined as \verb!Q! columns with some options):
  {Top Baseline \\ Left Left} & Middle Center & {Right Right \\ Bottom Baseline} \\
 \hline
 \end{tblr}
-\end{demohigh} 
+\end{demohigh}
 
 Note that you can use more meaningful \verb!t! instead of \verb!p! for top baseline alignment.
 For some users who are familiar with word processors,
@@ -271,7 +271,7 @@ which will help us to locate cells when the tables are rather complex:
 \begin{demohigh}
 \begin{tblr}{|ll|c|rr|}
 \hline
- \SetCell[r=3,c=2]{h} r=3 c=2 & 1-2 & \SetCell[r=2,c=3]{r} r=2 c=3 & 1-4 & 1-5 \\ 
+ \SetCell[r=3,c=2]{h} r=3 c=2 & 1-2 & \SetCell[r=2,c=3]{r} r=2 c=3 & 1-4 & 1-5 \\
  2-1 & 2-2 & 2-3 & 2-4 & 2-5 \\
 \hline
  3-1 & 3-2 & MIDDLE & \SetCell[r=3,c=2]{f} r=3 c=2 & 3-5 \\

--- a/manual/manual-2.tex
+++ b/manual/manual-2.tex
@@ -307,7 +307,7 @@ You can use child selectors in the mandatory argument of \verb!\cline!.
 \end{demohigh}
 
 Commands \verb!\SetHline! combines the usages of \verb!\hline! and \verb!\cline!:
- 
+
 \begin{demohigh}
 \begin{tblr}{llll}
 \SetHline{1-3}{blue5,1pt}

--- a/manual/manual-2.tex
+++ b/manual/manual-2.tex
@@ -42,7 +42,7 @@ hence totally separating the styles and the contents of tables.
   \verb!\SetColumn!                              & \K{column}, \K{colspec} \\
 \end{newtblr}
 
-\section{Hlines and Vlines}
+\section{Hlines and Vlines}\label{sec:hlines-vlines}
 
 All available keys for hlines and vlines are described in Table \ref{key:hline} and Table \ref{key:vline}.
 
@@ -58,6 +58,9 @@ All available keys for hlines and vlines are described in Table \ref{key:hline} 
   \underline{\K{fg}}   & rule color name & \None \\
   \K{leftpos}          & crossing or trimming position at the left side  & \V{1} \\
   \K{rightpos}         & crossing or trimming position at the right side & \V{1} \\
+  \K{l}                & same as \K{leftpos}, default \V{-0.8} & \V{1} \\
+  \K{r}                & same as \K{rightpos}, default \V{-0.8} & \V{1} \\
+  \K{lr}               & crossing or trimming positions at both sides, default \V{-0.8} & \V{1} \\
   \K{endpos}           & adjust leftpos/rightpos for only the leftmost/rightmost column & \V{false} \\
 \end{spectblr}
 \vspace{-2em}

--- a/manual/manual-5.tex
+++ b/manual/manual-5.tex
@@ -60,8 +60,11 @@ $f(x)=\begin{+cases}
 
 With \verb!\UseTblrLibrary{booktabs}! in the preamble of the document,
 \verb!tabularray! will load \verb!booktabs! package,
-and define \verb!\toprule!, \verb!\midrule!,
-\verb!\bottomrule! and \verb!\cmidrule! inside \verb!tblr! environment.
+and define
+  \verb!\toprule!, \verb!\midrule!, \verb!\bottomrule!,
+  \verb!\cmidrule!, \verb!\cmidrulemore!, \verb!\morecmidrules!,
+  \verb!\specialrule!, \verb!\addrowspace!, and \verb!\addlinespace!
+as table commands.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -92,7 +95,9 @@ you can also specify rule width and color in the optional argument of any of the
 \end{tblr}
 \end{demohigh}
 
-If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore! command.
+If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore!
+command, which is simpler than the \verb!booktabs! usage
+\verb!\morecmidrules\cmidrule!.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -166,7 +171,8 @@ and the third argument sets \verb!abovesep! of current row,
 \end{booktabs}
 \end{demohigh}
 
-At last, there is also an \verb!\addlinespace! command.
+At last, there is also an \verb!\addlinespace! command, with an alternative
+name \verb!\addrowspace!.
 You can specify the size of vertical space to be added in its optional argument,
 and the default size is \verb!0.5em!.
 This command adds one half of the space to \verb!belowsep! of previous row,

--- a/manual/manual-5.tex
+++ b/manual/manual-5.tex
@@ -117,8 +117,11 @@ command, which is simpler than the \verb!booktabs! usage
 \end{tblr}
 \end{demohigh}
 
-From version 2021N (2021-09-01), trim options (\verb!l!, \verb!r!, \verb!lr!)
-for \verb!\cmidrule! command are also supported.
+From version 2021N (2021-09-01), you can set trimming positions of
+\verb!\cmidrule! and \verb!\cmidrulemore!, using newly introduced trimming
+options (\verb!leftpos!, \verb!rightpos!, \verb!endpos!, \verb!l!, \verb!r!,
+and \verb!lr!) (see Section~\ref{sec:hlines-vlines}).
+Option \verb!endpos! is already applied to these two commands.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -132,11 +135,10 @@ for \verb!\cmidrule! command are also supported.
 \end{tblr}
 \end{demohigh}
 
-Note that you need to put \verb!l!, \verb!r! or \verb!lr! option into
-the \underline{\color{red3}square brackets}.
-and the possible values are decimal numbers between \verb!-1! and \verb!0!,
-where \verb!-1! means trimming the whole colsep, and \verb!0! means no trimming.
-The default value is \verb!-0.8!, which makes similar result as \verb!booktabs! package does.
+Since \verb!booktabs! tables usually don't have vlines, the meaningful values
+here are decimal numbers between \verb!-1! and \verb!0!.
+The default value \verb!-0.8! for \verb!l!, \verb!r!, and \verb!lr! is chosen to
+make similar result as \verb!booktabs! package does.
 
 There is also a \verb!booktabs! environment for you. With this environment,
 the default \verb!rowsep=0pt!, but extra vertical space will be added by

--- a/manual/manual-5.tex
+++ b/manual/manual-5.tex
@@ -81,7 +81,8 @@ as table commands.
 \end{demohigh}
 
 Just like \verb!\hline! and \verb!\cline! commands,
-you can also specify rule width and color in the optional argument of any of these commands.
+you can also specify rule width and color by using hline keys in the optional
+argument of any of these commands.
 
 Like in \verb!booktabs!, by default
   width of \verb!\toprule! and \verb!\bottomrule! are determined by \verb!\heavyrulewidth!,
@@ -102,8 +103,9 @@ All three \verb!\...rulewidth! are dimensions.
 \end{demohigh}
 
 If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore!
-command, which is simpler than the \verb!booktabs! usage
+command, which is simpler than the \verb!booktabs! usage 
 \verb!\morecmidrules\cmidrule!.
+\verb!\cmidrulemore! can receive hline keys in an optional argument too.
 
 \begin{demohigh}
 \begin{tblr}{llll}

--- a/manual/manual-5.tex
+++ b/manual/manual-5.tex
@@ -83,6 +83,12 @@ as table commands.
 Just like \verb!\hline! and \verb!\cline! commands,
 you can also specify rule width and color in the optional argument of any of these commands.
 
+Like in \verb!booktabs!, by default
+  width of \verb!\toprule! and \verb!\bottomrule! are determined by \verb!\heavyrulewidth!,
+  width of \verb!\midrule! is determined by \verb!\lightrulewidth!, and
+  width of \verb!\cmidrule! and \verb!\cmidrulemore! are determined by \verb!\cmidrulewidth!, respectively.
+All three \verb!\...rulewidth! are dimensions.
+
 \begin{demohigh}
 \begin{tblr}{llll}
 \toprule[2pt,purple3]
@@ -173,8 +179,9 @@ and the third argument sets \verb!abovesep! of current row,
 
 At last, there is also an \verb!\addlinespace! command, with an alternative
 name \verb!\addrowspace!.
-You can specify the size of vertical space to be added in its optional argument,
-and the default size is \verb!0.5em!.
+You can specify the size of vertical space to be added in its optional
+argument, and the default size is determinted by \verb!\defaultaddspace!
+dimension, initially \verb!0.5em!.
 This command adds one half of the space to \verb!belowsep! of previous row,
 and the other half to \verb!abovesep! of current row.
 

--- a/manual/manual-5.tex
+++ b/manual/manual-5.tex
@@ -103,7 +103,7 @@ All three \verb!\...rulewidth! are dimensions.
 \end{demohigh}
 
 If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore!
-command, which is simpler than the \verb!booktabs! usage 
+command, which is simpler than the \verb!booktabs! usage
 \verb!\morecmidrules\cmidrule!.
 \verb!\cmidrulemore! can receive hline keys in an optional argument too.
 

--- a/tabularray.tex
+++ b/tabularray.tex
@@ -209,7 +209,7 @@ If you don't like it, you could use \verb!\SetTblrInner! command:
  Iota    & Kappa & Lambda & Mu    \\
 \hline
 \end{tblr}
-\end{demohigh} 
+\end{demohigh}
 
 But in many cases, this \verb!rowsep! is useful:
 
@@ -248,7 +248,7 @@ just enclose the cell text with braces and use \verb!\\! to break lines:
  {L \\ Left} & {C \\ Cent \\ Center} & R \\
 \hline
 \end{tblr}
-\end{demohigh} 
+\end{demohigh}
 
 \section{Cell Alignment}
 
@@ -264,7 +264,7 @@ other columns are defined as \verb!Q! columns with some options):
  {Top Baseline \\ Left Left} & Middle Center & {Right Right \\ Bottom Baseline} \\
 \hline
 \end{tblr}
-\end{demohigh} 
+\end{demohigh}
 
 Note that you can use more meaningful \verb!t! instead of \verb!p! for top baseline alignment.
 For some users who are familiar with word processors,
@@ -418,7 +418,7 @@ which will help us to locate cells when the tables are rather complex:
 \begin{demohigh}
 \begin{tblr}{|ll|c|rr|}
 \hline
- \SetCell[r=3,c=2]{h} r=3 c=2 & 1-2 & \SetCell[r=2,c=3]{r} r=2 c=3 & 1-4 & 1-5 \\ 
+ \SetCell[r=3,c=2]{h} r=3 c=2 & 1-2 & \SetCell[r=2,c=3]{r} r=2 c=3 & 1-4 & 1-5 \\
  2-1 & 2-2 & 2-3 & 2-4 & 2-5 \\
 \hline
  3-1 & 3-2 & MIDDLE & \SetCell[r=3,c=2]{f} r=3 c=2 & 3-5 \\
@@ -872,7 +872,7 @@ You can use child selectors in the mandatory argument of \verb!\cline!.
 \end{demohigh}
 
 Commands \verb!\SetHline! combines the usages of \verb!\hline! and \verb!\cline!:
- 
+
 \begin{demohigh}
 \begin{tblr}{llll}
 \SetHline{1-3}{blue5,1pt}

--- a/tabularray.tex
+++ b/tabularray.tex
@@ -607,7 +607,7 @@ hence totally separating the styles and the contents of tables.
   \verb!\SetColumn!                              & \K{column}, \K{colspec} \\
 \end{newtblr}
 
-\section{Hlines and Vlines}
+\section{Hlines and Vlines}\label{sec:hlines-vlines}
 
 All available keys for hlines and vlines are described in Table \ref{key:hline} and Table \ref{key:vline}.
 
@@ -623,6 +623,9 @@ All available keys for hlines and vlines are described in Table \ref{key:hline} 
   \underline{\K{fg}}   & rule color name & \None \\
   \K{leftpos}          & crossing or trimming position at the left side  & \V{1} \\
   \K{rightpos}         & crossing or trimming position at the right side & \V{1} \\
+  \K{l}                & same as \K{leftpos}, default \V{-0.8} & \V{1} \\
+  \K{r}                & same as \K{rightpos}, default \V{-0.8} & \V{1} \\
+  \K{lr}               & crossing or trimming positions at both sides, default \V{-0.8} & \V{1} \\
   \K{endpos}           & adjust leftpos/rightpos for only the leftmost/rightmost column & \V{false} \\
 \end{spectblr}
 \vspace{-2em}
@@ -2471,8 +2474,11 @@ $f(x)=\begin{+cases}
 
 With \verb!\UseTblrLibrary{booktabs}! in the preamble of the document,
 \verb!tabularray! will load \verb!booktabs! package,
-and define \verb!\toprule!, \verb!\midrule!,
-\verb!\bottomrule! and \verb!\cmidrule! inside \verb!tblr! environment.
+and define
+  \verb!\toprule!, \verb!\midrule!, \verb!\bottomrule!,
+  \verb!\cmidrule!, \verb!\cmidrulemore!, \verb!\morecmidrules!,
+  \verb!\specialrule!, \verb!\addrowspace!, and \verb!\addlinespace!
+as table commands.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -2489,7 +2495,14 @@ and define \verb!\toprule!, \verb!\midrule!,
 \end{demohigh}
 
 Just like \verb!\hline! and \verb!\cline! commands,
-you can also specify rule width and color in the optional argument of any of these commands.
+you can also specify rule width and color by using hline keys in the optional
+argument of any of these commands.
+
+Like in \verb!booktabs!, by default
+  width of \verb!\toprule! and \verb!\bottomrule! are determined by \verb!\heavyrulewidth!,
+  width of \verb!\midrule! is determined by \verb!\lightrulewidth!, and
+  width of \verb!\cmidrule! and \verb!\cmidrulemore! are determined by \verb!\cmidrulewidth!, respectively.
+All three \verb!\...rulewidth! are dimensions.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -2503,7 +2516,10 @@ you can also specify rule width and color in the optional argument of any of the
 \end{tblr}
 \end{demohigh}
 
-If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore! command.
+If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore!
+command, which is simpler than the \verb!booktabs! usage
+\verb!\morecmidrules\cmidrule!.
+\verb!\cmidrulemore! can receive hline keys in an optional argument too.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -2517,8 +2533,11 @@ If you need more than one \verb!\cmidrule!s, you can use \verb!\cmidrulemore! co
 \end{tblr}
 \end{demohigh}
 
-From version 2021N (2021-09-01), trim options (\verb!l!, \verb!r!, \verb!lr!)
-for \verb!\cmidrule! command are also supported.
+From version 2021N (2021-09-01), you can set trimming positions of
+\verb!\cmidrule! and \verb!\cmidrulemore!, using newly introduced trimming
+options (\verb!leftpos!, \verb!rightpos!, \verb!endpos!, \verb!l!, \verb!r!,
+and \verb!lr!) (see Section~\ref{sec:hlines-vlines}).
+Option \verb!endpos! is already applied to these two commands.
 
 \begin{demohigh}
 \begin{tblr}{llll}
@@ -2532,11 +2551,10 @@ for \verb!\cmidrule! command are also supported.
 \end{tblr}
 \end{demohigh}
 
-Note that you need to put \verb!l!, \verb!r! or \verb!lr! option into
-the \underline{\color{red3}square brackets}.
-and the possible values are decimal numbers between \verb!-1! and \verb!0!,
-where \verb!-1! means trimming the whole colsep, and \verb!0! means no trimming.
-The default value is \verb!-0.8!, which makes similar result as \verb!booktabs! package does.
+Since \verb!booktabs! tables usually don't have vlines, the meaningful values
+here are decimal numbers between \verb!-1! and \verb!0!.
+The default value \verb!-0.8! for \verb!l!, \verb!r!, and \verb!lr! is chosen to
+make similar result as \verb!booktabs! package does.
 
 There is also a \verb!booktabs! environment for you. With this environment,
 the default \verb!rowsep=0pt!, but extra vertical space will be added by
@@ -2577,9 +2595,11 @@ and the third argument sets \verb!abovesep! of current row,
 \end{booktabs}
 \end{demohigh}
 
-At last, there is also an \verb!\addlinespace! command.
-You can specify the size of vertical space to be added in its optional argument,
-and the default size is \verb!0.5em!.
+At last, there is also an \verb!\addlinespace! command, with an alternative
+name \verb!\addrowspace!.
+You can specify the size of vertical space to be added in its optional
+argument, and the default size is determinted by \verb!\defaultaddspace!
+dimension, initially \verb!0.5em!.
 This command adds one half of the space to \verb!belowsep! of previous row,
 and the other half to \verb!abovesep! of current row.
 

--- a/testfiles/cell-001.tex
+++ b/testfiles/cell-001.tex
@@ -74,7 +74,7 @@ Alpha & Beta & Gamma \\
 
 \bigskip\hrule\bigskip
 
-%% h and t cells could align with t/m/b cells with strut 
+%% h and t cells could align with t/m/b cells with strut
 \BEGINTEST{normal cells: h/t/m/b/f cells with strut}
 \begin{tblr}{|Q[h]|Q[t]|Q[m]|Q[b]|Q[f]|}
 \hline

--- a/testfiles/hvline-003.tex
+++ b/testfiles/hvline-003.tex
@@ -89,7 +89,7 @@
   vline{4} = {2}{abovepos=0,belowpos=1},
 }
   AAAAAA & BBBBB  & CCCCC  \\
-  AAAAA  & BBBBBB & CCCCCC 
+  AAAAA  & BBBBBB & CCCCCC
 \end{tblr}
 \quad
 \begin{tblr}{

--- a/testfiles/library-013.tex
+++ b/testfiles/library-013.tex
@@ -22,7 +22,7 @@
 \zref@addprop{main}{table}
 \zref@addprop{main}{section}
 \zref@addprop{main}{subsection}
-\makeatother 
+\makeatother
 
 \begin{document}
 

--- a/testfiles/library-014.tex
+++ b/testfiles/library-014.tex
@@ -22,14 +22,14 @@
 \BEGINTEST{testing delimiters} % issue #300
 Hello$\begin{tblr}{}
   alpha & beta \\
-  delta & gamma \\ 
+  delta & gamma \\
 \end{tblr}$World
 \qquad
 Hello$\begin{tblr}{
   delimiter = {left=[,right=]}
 }
   alpha & beta \\
-  delta & gamma \\ 
+  delta & gamma \\
 \end{tblr}$World
 \ENDTEST
 

--- a/testfiles/long-003.tex
+++ b/testfiles/long-003.tex
@@ -30,7 +30,7 @@
 \hline
  \SetRow{purple7}
  Head & Head & Head \\
-\hline                               
+\hline
  \SetRow{purple7}
  Head & Head & Head \\
 \hline

--- a/testfiles/rowcol-004.tex
+++ b/testfiles/rowcol-004.tex
@@ -26,7 +26,7 @@
 \BEGINTEST{normal columns with large widths}
 \begin{tblr}{width=300pt,colspec=|l|Q[-1]|Q[-2]|Q[-5]|Q[-2]|l|Q[2]|Q[3]|l|}
 \hline
-\replicate{6}{\rule{10pt}{2pt}\hfil} & \rule{6pt}{2pt} & \rule{10pt}{2pt} & 
+\replicate{6}{\rule{10pt}{2pt}\hfil} & \rule{6pt}{2pt} & \rule{10pt}{2pt} &
 \rule{6pt}{2pt} & \rule{10pt}{2pt} & \replicate{7}{\rule{10pt}{2pt}\hfil} &
 \rule{10pt}{2pt} & \rule{6pt}{2pt} & \replicate{8}{\rule{10pt}{2pt}\hfil} \\
 \hline

--- a/testfiles/table-006.tex
+++ b/testfiles/table-006.tex
@@ -17,16 +17,16 @@
 
 \BEGINTEST{testing \SetTblrDefault}
 \begin{tblr}{}
-  A & B \\ C & D 
+  A & B \\ C & D
 \end{tblr}
 \begingroup
   \SetTblrDefault{hlines,vlines,stretch=2}
   \begin{tblr}{}
-    A & B \\ C & D 
+    A & B \\ C & D
   \end{tblr}
 \endgroup
 \begin{tblr}{}
-  A & B \\ C & D 
+  A & B \\ C & D
 \end{tblr}
 \ENDTEST
 

--- a/testfiles/table-010.tex
+++ b/testfiles/table-010.tex
@@ -23,43 +23,43 @@
 \begin{tblr}{lll}
 
 \hline
- 
+
   One
-  
+
   &
-  
+
   Two
-  
+
   &
-  
+
   Three
-  
-  \\ 
- 
+
+  \\
+
   Four
-  
-  & 
-  
+
+  &
+
   Five
-  
+
   &
-  
+
   Six
-  
-  \\ 
- 
+
+  \\
+
   Seven
-  
+
   &
-  
+
   Eight
-  
+
   &
-  
+
   Nine
-  
-  \\ 
- 
+
+  \\
+
 \hline
 
 \end{tblr}

--- a/testfiles/table-013.tex
+++ b/testfiles/table-013.tex
@@ -31,7 +31,7 @@
 \caption{Short Table}
 \begin{tblr}{hlines}
   \tblrbody
-\end{tblr} 
+\end{tblr}
 \end{table}
 \begin{table}[!htpb]
 \centering


### PR DESCRIPTION
Main changes

- add missing `booktabs` table commands
- mention all used dimensions defined by `booktabs` package
- move documentation of trimming options `l/r/lr` from `booktabs` lib section to the (general) hlines and vlines section

**WARNING**

`tabularray.tex` is not updated, due to EOL issue previously encountered and discussed in https://github.com/lvjr/tabularray/pull/385#issuecomment-1474807700.

Here I have to apply patch
```diff
diff --git a/manual.lua b/manual.lua
index 1d6b44e..0abd3a9 100644
--- a/manual.lua
+++ b/manual.lua
@@ -7,7 +7,8 @@ local function ReadFile(input)
     print("Error in reading " .. input)
     return
   end
-  local text = f:read("*all")
+  -- normalize line endings, https://stackoverflow.com/a/20599512
+  local text = f:read("*all"):gsub('\r\n?', '\n')
   f:close()
   return text
 end
```
to overcome lua error
```
manual.lua:29: attempt to concatenate a nil value (local 'body')
```
thrown when executing `texlua manual.lua`. Even then, a Git warning
```
warning: in the working copy of 'tabularray.tex', LF will be replaced by CRLF the next time Git touches it
```
is encountered. 

`tabularray` (and perhaps other open source repos by the same author) need a workflow to allow users on OS's using different EOL characters working together.