### PR TITLE
Made expand work with multiple macro names

### DIFF
--- a/manual/manual-3.tex
+++ b/manual/manual-3.tex
@@ -233,6 +233,7 @@ there are several other outer specifications which are described in Table~\ref{k
   \K{long} & change the table to a long table & \None \\
   \K{tall} & change the table to a tall table & \None \\
   \K{expand} & you need this key to use verb commands & \None \\
+  \K{expand+} & like \K{expand} but appends to previous values & \None \\
 \end{spectblr}
 
 \subsection{Set Baseline in Another Way}
@@ -270,19 +271,27 @@ In contrast to traditional \verb!tabular! environment, \verb!tabularray! environ
 need to see every \verb!&! and \verb!\\! when splitting the table body with \verb!l3regex!.
 And you can not put cell text inside any table command defined with \verb!\NewTableCommand!.
 But you could use outer key \verb!expand! to make \verb!tabularray! expand
-every occurrence of a specified macro \underline{once} before splitting the table body.
+every occurrence of any of the specified macros \underline{once} and \underline{in the given oder} before splitting the table body.
 Note that you \underline{can not} expand a command defined with \verb!\NewDocumentCommand!.
+You can also use \verb!expand+! if you still want to keep the macros in the current \verb!expand! setting.
 
 To expand a command without optional argument, you can define it with \verb!\newcommand!.
 
 \begin{demohigh}
+\newcommand*\tblrrowa{
+	20 & 30 & 40 \\ }
+\newcommand*\tblrrowb{
+	50 & 60 & 70 \\ }
+
 \newcommand*\tblrbody{
  \hline
-  20 & 30 & 40 \\
-  50 & 60 & 70 \\
+  \tblrrowa
+  \tblrrowb
  \hline
 }
-\begin{tblr}[expand=\tblrbody]{ccc}
+
+\SetTblrOuter{expand=\tblrbody\tblrrowa}
+\begin{tblr}[expand+=\tblrrowb]{ccc}
  \hline
   AA & BB & CC \\
   \tblrbody

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -2771,11 +2771,9 @@
   {
     \__tblr_hook_split_before:
     \tl_set:Nx \l__tblr_expand_tl { \__tblr_spec_item:nn { outer } { expand } }
-    \tl_set:Nx \l__tblr_expand_tl { \tl_head:N \l__tblr_expand_tl }
-    \tl_if_empty:NF \l__tblr_expand_tl
+    \tl_map_inline:Nn \l__tblr_expand_tl
       {
-        \exp_last_unbraced:NNV
-        \__tblr_expand_table_body:NN \l__tblr_body_tl \l__tblr_expand_tl
+        \__tblr_expand_table_body:NN \l__tblr_body_tl ##1
       }
   }
 
@@ -3213,6 +3211,7 @@
     B       .meta:n = { baseline = B },
     valign  .meta:n = { baseline = #1 }, % obsolete, will be removed some day
     expand  .code:n = \__tblr_outer_gput_spec:nn { expand } {#1},
+    expand+ .code:n = \__tblr_outer_gconcat_spec:nn { expand } {#1},
     headsep .code:n = \__tblr_outer_gput_spec:nn { headsep } {#1},
     footsep .code:n = \__tblr_outer_gput_spec:nn { footsep } {#1},
     presep  .code:n = \__tblr_outer_gput_spec:nn { presep }  {#1},
@@ -3229,6 +3228,11 @@
     \__tblr_spec_gput:nen { outer } {#1} {#2}
   }
 \cs_generate_variant:Nn \__tblr_outer_gput_spec:nn { ne }
+
+\cs_new_protected:Npn \__tblr_outer_gconcat_spec:nn #1 #2
+  {
+    \__tblr_outer_gput_spec:ne {#1} { \__tblr_spec_item:nn { outer } { #1 } \exp_not:n { #2 } }
+  }
 
 \regex_const:Nn \c__tblr_option_key_name_regex { ^ [A-Za-z\-] + $ }
 

--- a/tabularray.tex
+++ b/tabularray.tex
@@ -1570,6 +1570,7 @@ there are several other outer specifications which are described in Table~\ref{k
   \K{long} & change the table to a long table & \None \\
   \K{tall} & change the table to a tall table & \None \\
   \K{expand} & you need this key to use verb commands & \None \\
+  \K{expand+} & like \K{expand} but appends to previous values & \None \\
 \end{spectblr}
 
 \subsection{Set Baseline in Another Way}
@@ -1607,19 +1608,27 @@ In contrast to traditional \verb!tabular! environment, \verb!tabularray! environ
 need to see every \verb!&! and \verb!\\! when splitting the table body with \verb!l3regex!.
 And you can not put cell text inside any table command defined with \verb!\NewTableCommand!.
 But you could use outer key \verb!expand! to make \verb!tabularray! expand
-every occurrence of a specified macro \underline{once} before splitting the table body.
+every occurrence of any of the specified macros \underline{once} and \underline{in the given oder} before splitting the table body.
 Note that you \underline{can not} expand a command defined with \verb!\NewDocumentCommand!.
+You can also use \verb!expand+! if you still want to keep the macros in the current \verb!expand! setting.
 
 To expand a command without optional argument, you can define it with \verb!\newcommand!.
 
 \begin{demohigh}
+\newcommand*\tblrrowa{
+	20 & 30 & 40 \\ }
+\newcommand*\tblrrowb{
+	50 & 60 & 70 \\ }
+
 \newcommand*\tblrbody{
  \hline
-  20 & 30 & 40 \\
-  50 & 60 & 70 \\
+  \tblrrowa
+  \tblrrowb
  \hline
 }
-\begin{tblr}[expand=\tblrbody]{ccc}
+
+\SetTblrOuter{expand=\tblrbody\tblrrowa}
+\begin{tblr}[expand+=\tblrrowb]{ccc}
  \hline
   AA & BB & CC \\
   \tblrbody

--- a/testfiles/extra-001.tex
+++ b/testfiles/extra-001.tex
@@ -17,13 +17,18 @@
 \hrule\bigskip
 
 \BEGINTEST{testing expand option}
+\def\tblrrowa{
+	20 & 30 & 40 \\ }
+\def\tblrrowb{
+	50 & 60 & 70 \\ }
 \def\tblrbody{
  \hline
-  20 & 30 & 40 \\
-  50 & 60 & 70 \\
+  \tblrrowa
+  \tblrrowb
  \hline
 }
-\begin{tblr}[expand=\tblrbody]{ccc}
+\SetTblrOuter{expand=\tblrbody\tblrrowa}
+\begin{tblr}[expand+=\tblrrowb]{ccc}
  \hline
   AA & BB & CC \\
   \tblrbody


### PR DESCRIPTION
I've made it so that the outer key `expand` can take multiple macros. I've also added an `expand+` key that doesn't overwritte previouse `expand` settings.
I've changed the example in the manual to show off these new features:
```
\newcommand*\tblrrowa{
	20 & 30 & 40 \\ }
\newcommand*\tblrrowb{
	50 & 60 & 70 \\ }
\newcommand*\tblrbody{
 \hline
  \tblrrowa
  \tblrrowb
 \hline
}
\SetTblrOuter{expand=\tblrbody\tblrrowa}
\begin{tblr}[expand+=\tblrrowb]{ccc}
 \hline
  AA & BB & CC \\
  \tblrbody
  DD & EE & FF \\
  \tblrbody
  GG & HH & II \\
 \hline
\end{tblr}
```

Note that the ordering of the macros is important, `\tblrrowa` must go after `\tblrbody` as `tblr` will only see the `\tblrrowa`'s will only appear in the body after `\tblrbody` has been expanded.