### PR TITLE
Use hborders from  the head and the foot when splitting lontblr

### DIFF
--- a/tabularray.sty
+++ b/tabularray.sty
@@ -5606,13 +5606,19 @@
           \l_tmpa_dim \l__tblr_page_break_curr_bool
         % Add the difference between the belowsep from the row above the foot and the row
         % tested for a pagebreak to make the total table height on the page accurate
-        \dim_set:Nn \l_tmpb_dim
+        \int_compare:nNnTF {\l__tblr_prev_i_int} > { 0 }
         {
-          \l_tmpa_dim
-          +
-          \__tblr_data_item:nen { row } { \int_use:N \l__tblr_long_row_before_foot_int } { belowsep }
-          -
-          \__tblr_data_item:nen { row } { \int_use:N \l__tblr_prev_i_int } { belowsep }
+          \dim_set:Nn \l_tmpb_dim
+          {
+            \l_tmpa_dim
+            +
+            \__tblr_data_item:nen { row } { \int_use:N \l__tblr_long_row_before_foot_int } { belowsep }
+            -
+            \__tblr_data_item:nen { row } { \int_use:N \l__tblr_prev_i_int } { belowsep }
+          }
+        }
+        {
+          \dim_set:Nn \l_tmpb_dim \l_tmpa_dim
         }
         \__tblr_check_table_page_break:NNN
           \l__tblr_remain_height_dim \l_tmpb_dim \l__tblr_page_break_prev_bool

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -5557,6 +5557,8 @@
   }
 
 \dim_new:N \l__tblr_remain_height_dim
+\int_new:N \l__tblr_long_row_after_head_int
+\int_new:N \l__tblr_long_row_before_foot_int
 \int_new:N \l__tblr_long_from_int
 \int_new:N \l__tblr_long_to_int
 \int_new:N \l__tblr_curr_i_int
@@ -5589,16 +5591,31 @@
     \dim_set:Nn \l__tblr_remain_height_dim
       { \pagegoal - \pagetotal - \l__tblr_row_head_foot_dim }
     \int_set:Nn \l__tblr_long_from_int { \l__tblr_row_head_tl + 1 }
+    \int_set:Nn \l__tblr_long_row_after_head_int { \l__tblr_long_from_int }
     \int_set:Nn \l__tblr_long_to_int { \c@rowcount - ( \l__tblr_row_foot_tl + 0 ) }
+    \int_set:Nn \l__tblr_long_row_before_foot_int { \l__tblr_long_to_int }
     \int_set:Nn \l__tblr_curr_i_int { \l__tblr_long_from_int - 1 }
     \int_do_while:nNnn { \l__tblr_curr_i_int } < { \l__tblr_long_to_int }
       {
         \int_set_eq:NN \l__tblr_prev_i_int \l__tblr_curr_i_int
+        % Copy the abovesep from the row below the head to the row below the head on the current page
+        \__tblr_data_gput:nene { row } { \int_use:N \l__tblr_long_from_int }
+          { abovesep } { \__tblr_data_item:nen { row } { \int_use:N \l__tblr_long_row_after_head_int } { abovesep } }
         \__tblr_get_next_table_rows:NNNN
           \l__tblr_long_to_int \l__tblr_curr_i_int
           \l_tmpa_dim \l__tblr_page_break_curr_bool
+        % Add the difference between the belowsep from the row above the foot and the row
+        % tested for a pagebreak to make the total table height on the page accurate
+        \dim_set:Nn \l_tmpb_dim
+        {
+          \l_tmpa_dim
+          +
+          \__tblr_data_item:nen { row } { \int_use:N \l__tblr_long_row_before_foot_int } { belowsep }
+          -
+          \__tblr_data_item:nen { row } { \int_use:N \l__tblr_prev_i_int } { belowsep }
+        }
         \__tblr_check_table_page_break:NNN
-          \l__tblr_remain_height_dim \l_tmpa_dim \l__tblr_page_break_prev_bool
+          \l__tblr_remain_height_dim \l_tmpb_dim \l__tblr_page_break_prev_bool
         \__tblr_do_if_tracing:nn { page } { \int_log:N \l__tblr_curr_i_int }
         \bool_if:NTF \l__tblr_page_break_prev_bool
           {
@@ -5624,6 +5641,9 @@
                 \group_end:
               }
               {
+                % Copy the belowsep from the row above the foot to the row above the foot on the current page
+                \__tblr_data_gput:nene { row } { \int_use:N \l__tblr_prev_i_int }
+                  { belowsep } { \__tblr_data_item:nen { row } { \int_use:N \l__tblr_long_row_before_foot_int } { belowsep } }
                 \__tblr_build_page_table:nnx {#1}
                   { \int_use:N \l__tblr_long_from_int }
                   { \int_use:N \l__tblr_prev_i_int }


### PR DESCRIPTION
Hi! It's rather a request for comment than a pull request: Currently, the `longtblr` (and `longtabs`) environment produces inconsistent hborders for hlines separating the head and the foot from the rest of the table when splitting it into pages. I'm attaching an example (a bit exaggerated) to show this.
[tblr.pdf](https://github.com/lvjr/tabularray/files/14872283/tblr.pdf)

What I've tried in this PR, is to copy the hborder (actually, the corresponding abovesep and belowsep since they are the only information left after parsing the table initially) from the first page (for the head) and from the last page (for the foot) to the rest of the pages.

The patch is fairly simple, but may be there is a better way.

Here is the test file (the second column is for comparison with booktabs).

```
\documentclass[a5paper,12pt]{article}
\usepackage[margin=0.5cm]{geometry}
\usepackage{booktabs}
\usepackage{tabularray}
\UseTblrLibrary{booktabs}
\usepackage{paracol}
\usepackage{xtab}

\setlength{\aboverulesep}{10pt}
\setlength{\belowrulesep}{10pt}

\usepackage{}

\begin{document}
\begin{paracol}{2}

\vspace*{-27.2pt}
\begin{longtabs}
[
 caption = {A Table},
 label = {tblr:test},
]{
 colspec = {lll},
 rowhead = 2,
 rowfoot = 1,
 rows = {rowsep=0pt},
}
\toprule
 Head & Head & Head \\
 Head & Head & Head \\
\midrule
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
\midrule
 Foot & Foot & Foot \\
\bottomrule
\end{longtabs}

\switchcolumn

\centering
\topcaption{A Table} \label{tab:xtab}
\tablefirsthead{
\\[-2ex]
\toprule
 Head & Head & Head \\
 Head & Head & Head \\
\midrule}
\tablehead{\multicolumn{3}{c}{{\tablename\ \thetable: A Table (Continued)}}\\[0.87ex]
\toprule
 Head & Head & Head \\
 Head & Head & Head \\
\midrule}
\tabletail{\midrule
 Foot & Foot & Foot \\
 \bottomrule}
\tablelasttail{\midrule
 Foot & Foot & Foot \\
 \bottomrule}
\begin{xtabular}{lll}
 \shrinkheight{-2.9in}
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 \shrinkheight{-2.9in}
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
 Alpha & Beta & Gamma \\
 Epsilon & Zeta & Eta \\
 Iota & Kappa & Lambda \\
 Nu & Xi & Omicron \\
 Rho & Sigma & Tau \\
 Phi & Chi & Psi \\
\end{xtabular}

\end{paracol}

\end{document}
```
