### PR TITLE
Add tikz library

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,6 @@
 name: Run benchmark tests in TeX Live
 
-on: [push, pull_request]
+on: push
 
 jobs:
   run-ubuntu:

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -7540,10 +7540,9 @@
 \dim_new:N \l__tblr_cell_inner_wd_dim
 \dim_new:N \l__tblr_cell_hcenter_dim
 \dim_new:N \l__tblr_cell_vcenter_dim
-\dim_new:N \l__tblr_table_height_dim
-\dim_new:N \l__tblr_table_depth_dim
-\dim_new:N \l__tblr_last_hline_height_dim
-\dim_new:N \l__tblr_last_vline_width_dim
+\dim_new:N \l__tblr_last_cell_table_ht_dim
+\dim_new:N \l__tblr_last_cell_table_dp_dim
+\dim_new:N \l__tblr_last_vline_wd_dim
 \box_new:N \l__tblr_tikz_node_box
 
 \NewTblrLibrary { tikz }
@@ -7558,7 +7557,7 @@
 
     \UseTblrLibrary { hook }
     \RequirePackage { tikz }
-    \tikzset {
+    \tikzset{
         tblr / cell ~ node / .style = {
             rectangle ,
             inner ~ sep = 0pt ,
@@ -7627,10 +7626,7 @@
                 \__tblr_get_table_width:
                 \__tblr_get_table_height:
                 \__tblr_get_table_depth:
-                \dim_set:Nn \l__tblr_last_hline_height_dim {
-                    \__tblr_spec_item:nn { hline } { [ \int_eval:n { \c@rowcount + 1 } ] / @hline-height }
-                }
-                \dim_set:Nn \l__tblr_last_vline_width_dim {
+                \dim_set:Nn \l__tblr_last_vline_wd_dim {
                     \__tblr_spec_item:nn { vline } { [ \int_eval:n { \c@colcount + 1 } ] / @vline-width }
                 }
                 \hbox_set:Nn \l__tblr_tikz_node_box {
@@ -7639,8 +7635,8 @@
                         tblr / table ~ node ,
                         tblr / table ,
                         text ~ width = \tablewidth ,
-                        text ~ height = \l__tblr_table_height_dim ,
-                        text ~ depth = \l__tblr_table_depth_dim
+                        text ~ height = \l__tblr_last_cell_table_ht_dim ,
+                        text ~ depth = \l__tblr_last_cell_table_dp_dim
                     ] (
                         \g__tblr_tikz_prefix_tl
                         tblr
@@ -7649,16 +7645,16 @@
                 }
                 \box_set_trim:Nnnnn \l__tblr_tikz_node_box {
                     0.5 \tablewidth +
-                    \l__tblr_last_vline_width_dim
+                    \l__tblr_last_vline_wd_dim
                 } {
-                    -0.5 \l__tblr_table_height_dim +
-                    0.5 \l__tblr_table_depth_dim
+                    -0.5 \l__tblr_last_cell_table_ht_dim +
+                    0.5 \l__tblr_last_cell_table_dp_dim
                 } {
                     -0.5 \tablewidth -
-                    \l__tblr_last_vline_width_dim
+                    \l__tblr_last_vline_wd_dim
                 } {
-                    0.5 \l__tblr_table_height_dim -
-                    0.5 \l__tblr_table_depth_dim
+                    0.5 \l__tblr_last_cell_table_ht_dim -
+                    0.5 \l__tblr_last_cell_table_dp_dim
                 }
                 \box_use:N \l__tblr_tikz_node_box
             }
@@ -7668,28 +7664,29 @@
 
 \cs_new_protected:Npn \__tblr_get_table_height:
   {
+    \dim_zero:N \l__tblr_last_cell_table_ht_dim
     \int_step_inline:nn { \c@rowcount - 1 } {
-        \dim_add:Nn \l__tblr_table_height_dim {
+        \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
             \__tblr_valign_get_hline_total:n {##1}
         }
-        \dim_add:Nn \l__tblr_table_height_dim {
+        \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
             \__tblr_valign_get_row_total:n {##1}
         }
     }
-    \dim_add:Nn \l__tblr_table_height_dim {
+    \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
         \__tblr_valign_get_hline_total:n { \int_use:N \c@rowcount }
     }
-    \dim_add:Nn \l__tblr_table_height_dim {
+    \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
         \__tblr_valign_get_row_height:n { \int_use:N \c@rowcount }
     }
   }
 
 \cs_new_protected:Npn \__tblr_get_table_depth:
   {
-    \dim_set:Nn \l__tblr_table_depth_dim {
+    \dim_set:Nn \l__tblr_last_cell_table_dp_dim {
         \__tblr_valign_get_row_depth:n { \int_use:N \c@rowcount }
     }
-    \dim_add:Nn \l__tblr_table_depth_dim {
+    \dim_add:Nn \l__tblr_last_cell_table_dp_dim {
         \__tblr_valign_get_hline_total:n { \int_eval:n { \c@rowcount + 1 } }
     }
   }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -7534,3 +7534,32 @@
       }
   }
 
+%% Library tikzmark to add tikzmarks at the lower left corner of each cell
+
+\tl_new:N \l__tblr_tikzmark_prefix_tl
+\box_new:N \l__tblr_tikzmark_box
+
+\NewTblrLibrary { tikzmark }
+  {
+    \__tblr_keys_define:nn { table / inner }
+        { 
+            tikzmark ~ prefix .code:n = {
+                \tl_set:Nn \l__tblr_tikzmark_prefix_tl { ##1 - } 
+            } 
+        }
+    \UseTblrLibrary { hook }
+    \RequirePackage { tikz }
+    \usetikzlibrary { tikzmark }
+    \AddToHook { tabularray/cell/before } {
+        \hbox_set:Nn \l__tblr_tikzmark_box { 
+          \tikzmark{ \l__tblr_tikzmark_prefix_tl tblr - \arabic{colnum} - \arabic{rownum} } 
+        }
+        \box_set_trim:Nnnnn \l__tblr_tikzmark_box 
+            { 0.5\rulewidth }
+            { 0.5\rulewidth }
+            { -0.5\rulewidth }
+            { -0.5\rulewidth }
+        \box_move_down:nn { \dim_eval:n { \l__tblr_row_dp_dim } }
+            { \box_use:N \l__tblr_tikzmark_box }
+    }
+  }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -7538,8 +7538,8 @@
 
 \tl_new:N \g__tblr_tikz_prefix_tl
 \dim_new:N \l__tblr_cell_inner_wd_dim
-\dim_new:N \l__tblr_cell_hcenter_dim
-\dim_new:N \l__tblr_cell_vcenter_dim
+\dim_new:N \l__tblr_cell_inner_dp_dim
+\dim_new:N \l__tblr_cell_hanchor_dim
 \dim_new:N \l__tblr_last_cell_table_ht_dim
 \dim_new:N \l__tblr_last_cell_table_dp_dim
 \dim_new:N \l__tblr_last_vline_wd_dim
@@ -7549,144 +7549,184 @@
   {
     \keys_define:nn { tblr }
     %\__tblr_keys_define:nn { table / inner }
-        {
-            tikz ~ prefix .code:n = {
-                \tl_gset:Nn \g__tblr_tikz_prefix_tl { ##1 - }
-            }
-        }
+      {
+        tikz ~ prefix .code:n =
+          {
+            \tl_gset:Nn \g__tblr_tikz_prefix_tl { ##1 - }
+          }
+      }
 
     \UseTblrLibrary { hook }
     \RequirePackage { tikz }
-    \tikzset{
-        tblr / cell ~ node / .style = {
+    \tikzset
+      {
+        tblr / cell ~ node / .style =
+          {
             rectangle ,
             inner ~ sep = 0pt ,
             draw = none ,
             fill = none
-        } ,
+          } ,
         tblr / cell / .style = { } ,
-        tblr / table ~ node / .style = {
+        tblr / table ~ node / .style =
+          {
             rectangle ,
             inner ~ sep = 0pt ,
             draw = none ,
             fill = none
-        } ,
+          } ,
         tblr / table / .style = { } ,
         tblr / overlay / .style = { }
-    }
+      }
 
-    \NewDocumentEnvironment { tblrtikz } { } {
-      \begin{tikzpicture}[
-        remember ~ picture ,
-        overlay ,
-        name ~ prefix = \g__tblr_tikz_prefix_tl ,
-        tblr / overlay
-      ]
-    }{
-      \end{tikzpicture}
-    }
+    \NewDocumentEnvironment { tblrtikz } { }
+      {
+        \begin{tikzpicture}
+          [
+            remember ~ picture ,
+            overlay ,
+            name ~ prefix = \g__tblr_tikz_prefix_tl ,
+            tblr / overlay
+          ]
+      }
+      {
+        \end{tikzpicture}
+      }
 
-    \AddToHook { tabularray/cell/after } {
-        \dim_set:Nn \l__tblr_cell_inner_wd_dim {
-            \l__tblr_x_tl + \l__tblr_y_tl +
-            \l__tblr_cell_wd_dim
-        }
-        \hbox_set:Nn \l__tblr_tikz_node_box {
-          \begin{tikzpicture}[remember ~ picture, overlay]
-            \node[
-                tblr / cell ~ node ,
-                tblr / cell ,
-                text ~ width = \l__tblr_cell_inner_wd_dim ,
-                text ~ height = \l__tblr_row_ht_dim ,
-                text ~ depth = \l__tblr_row_dp_dim
-            ] (
-                \g__tblr_tikz_prefix_tl
-                tblr -
-                \int_use:N \c@rownum -
-                \int_use:N \c@colnum
-            ) at ( 0pt , 0pt ) { } ;
-          \end{tikzpicture}
-        }
-        \dim_set:Nn \l__tblr_cell_hcenter_dim {
-            0.5 \l__tblr_cell_inner_wd_dim
-        }
-        \dim_set:Nn \l__tblr_cell_vcenter_dim {
-            0.5 \l__tblr_row_ht_dim -
-            0.5 \l__tblr_row_dp_dim
-        }
+    \AddToHook { tabularray/cell/after }
+      {
+        \__tblr_get_cell_background_width:NNN
+            \c@rownum \c@colnum \l__tblr_cell_inner_wd_dim
+        \__tblr_get_cell_background_depth:NNN
+            \c@rownum \c@colnum\l__tblr_cell_inner_dp_dim
+        \dim_zero:N \l__tblr_cell_hanchor_dim
+        \tl_set:Ne \l__tblr_c_tl
+          { \__tblr_data_item:neen { cell }
+          { \int_use:N \c@rownum } { \int_use:N \c@colnum } { colspan } }
+        \int_step_inline:nn { \l__tblr_c_tl }
+          {
+            \int_compare:nNnT {##1} > { 1 }
+              {
+                \dim_add:Nn \l__tblr_cell_hanchor_dim
+                  {
+                    \__tblr_data_item:neen { cell } { \int_use:N \c@rownum } {##1} { @cell-width }
+                    -
+                    \__tblr_data_item:nen { column } {##1} { @col-width }
+                  }
+              }
+          }
+        \hbox_set:Nn \l__tblr_tikz_node_box
+          {
+            \begin{tikzpicture}[remember ~ picture, overlay]
+              \node
+                [
+                  tblr / cell ~ node ,
+                  tblr / cell ,
+                  text ~ width = \l__tblr_cell_inner_wd_dim ,
+                  text ~ height = \l__tblr_row_ht_dim ,
+                  text ~ depth = \l__tblr_cell_inner_dp_dim
+                ]
+                (
+                  \g__tblr_tikz_prefix_tl
+                  tblr -
+                  \int_use:N \c@rownum -
+                  \int_use:N \c@colnum
+                )
+                at ( 0pt , 0pt ) { } ;
+            \end{tikzpicture}
+          }
         \box_set_trim:Nnnnn \l__tblr_tikz_node_box
-            { \l__tblr_cell_hcenter_dim }
-            { -\l__tblr_cell_vcenter_dim }
-            { -\l__tblr_cell_hcenter_dim }
-            { \l__tblr_cell_vcenter_dim }
+          {
+            0.5 \l__tblr_cell_inner_wd_dim +
+            \l__tblr_cell_hanchor_dim
+          }
+          {
+            -0.5 \l__tblr_row_ht_dim +
+            0.5 \l__tblr_cell_inner_dp_dim
+          }
+          {
+            -0.5 \l__tblr_cell_inner_wd_dim -
+            \l__tblr_cell_hanchor_dim
+          }
+          {
+            0.5 \l__tblr_row_ht_dim -
+            0.5 \l__tblr_cell_inner_dp_dim
+          }
         \box_use:N \l__tblr_tikz_node_box
 
-        \int_compare:nNnT { \c@rownum } = { \c@rowcount } {
-            \int_compare:nNnT { \c@colnum } = { \c@colcount } {
+        \int_compare:nNnT { \c@rownum } = { \c@rowcount }
+          {
+            \int_compare:nNnT { \c@colnum } = { \c@colcount }
+              {
                 \__tblr_get_table_width:
                 \__tblr_get_table_height:
                 \__tblr_get_table_depth:
-                \dim_set:Nn \l__tblr_last_vline_wd_dim {
-                    \__tblr_spec_item:nn { vline } { [ \int_eval:n { \c@colcount + 1 } ] / @vline-width }
-                }
-                \hbox_set:Nn \l__tblr_tikz_node_box {
-                  \begin{tikzpicture}[remember ~ picture, overlay]
-                    \node[
-                        tblr / table ~ node ,
-                        tblr / table ,
-                        text ~ width = \tablewidth ,
-                        text ~ height = \l__tblr_last_cell_table_ht_dim ,
-                        text ~ depth = \l__tblr_last_cell_table_dp_dim
-                    ] (
-                        \g__tblr_tikz_prefix_tl
-                        tblr
-                    ) at ( 0pt , 0pt ) { } ;
-                  \end{tikzpicture}
-                }
-                \box_set_trim:Nnnnn \l__tblr_tikz_node_box {
+                \dim_set:Nn \l__tblr_last_vline_wd_dim
+                  {
+                    \__tblr_spec_item:nn { vline }
+                      { [ \int_eval:n { \c@colcount + 1 } ] / @vline-width }
+                  }
+                \hbox_set:Nn \l__tblr_tikz_node_box
+                  {
+                    \begin{tikzpicture}[remember ~ picture, overlay]
+                      \node
+                        [
+                          tblr / table ~ node ,
+                          tblr / table ,
+                          text ~ width = \tablewidth ,
+                          text ~ height = \l__tblr_last_cell_table_ht_dim ,
+                          text ~ depth = \l__tblr_last_cell_table_dp_dim
+                        ]
+                        (
+                          \g__tblr_tikz_prefix_tl
+                          tblr
+                        )
+                        at ( 0pt , 0pt ) { } ;
+                    \end{tikzpicture}
+                  }
+                \box_set_trim:Nnnnn \l__tblr_tikz_node_box
+                  {
                     0.5 \tablewidth +
                     \l__tblr_last_vline_wd_dim
-                } {
+                  }
+                  {
                     -0.5 \l__tblr_last_cell_table_ht_dim +
                     0.5 \l__tblr_last_cell_table_dp_dim
-                } {
+                  }
+                  {
                     -0.5 \tablewidth -
                     \l__tblr_last_vline_wd_dim
-                } {
+                  }
+                  {
                     0.5 \l__tblr_last_cell_table_ht_dim -
                     0.5 \l__tblr_last_cell_table_dp_dim
-                }
+                  }
                 \box_use:N \l__tblr_tikz_node_box
-            }
-        }
-    }
+              }
+          }
+      }
   }
 
 \cs_new_protected:Npn \__tblr_get_table_height:
   {
     \dim_zero:N \l__tblr_last_cell_table_ht_dim
-    \int_step_inline:nn { \c@rowcount - 1 } {
-        \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
-            \__tblr_valign_get_hline_total:n {##1}
-        }
-        \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
-            \__tblr_valign_get_row_total:n {##1}
-        }
-    }
-    \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
-        \__tblr_valign_get_hline_total:n { \int_use:N \c@rowcount }
-    }
-    \dim_add:Nn \l__tblr_last_cell_table_ht_dim {
-        \__tblr_valign_get_row_height:n { \int_use:N \c@rowcount }
-    }
+    \int_step_inline:nn { \c@rowcount - 1 }
+      {
+        \dim_add:Nn \l__tblr_last_cell_table_ht_dim
+          { \__tblr_valign_get_hline_total:n {##1} }
+        \dim_add:Nn \l__tblr_last_cell_table_ht_dim
+          { \__tblr_valign_get_row_total:n {##1} }
+      }
+    \dim_add:Nn \l__tblr_last_cell_table_ht_dim
+      { \__tblr_valign_get_hline_total:n { \int_use:N \c@rowcount } }
+    \dim_add:Nn \l__tblr_last_cell_table_ht_dim
+      { \__tblr_valign_get_row_height:n { \int_use:N \c@rowcount } }
   }
 
 \cs_new_protected:Npn \__tblr_get_table_depth:
   {
-    \dim_set:Nn \l__tblr_last_cell_table_dp_dim {
-        \__tblr_valign_get_row_depth:n { \int_use:N \c@rowcount }
-    }
-    \dim_add:Nn \l__tblr_last_cell_table_dp_dim {
-        \__tblr_valign_get_hline_total:n { \int_eval:n { \c@rowcount + 1 } }
-    }
+    \dim_set:Nn \l__tblr_last_cell_table_dp_dim
+      { \__tblr_valign_get_row_depth:n { \int_use:N \c@rowcount } }
+    \dim_add:Nn \l__tblr_last_cell_table_dp_dim
+      { \__tblr_valign_get_hline_total:n { \int_eval:n { \c@rowcount + 1 } } }
   }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -7534,32 +7534,162 @@
       }
   }
 
-%% Library tikzmark to add tikzmarks at the lower left corner of each cell
+%% Library to add tikz coordinates at the corners of each cell as well as of the whole table
 
-\tl_new:N \l__tblr_tikzmark_prefix_tl
-\box_new:N \l__tblr_tikzmark_box
+\tl_new:N \g__tblr_tikz_prefix_tl
+\dim_new:N \l__tblr_cell_inner_wd_dim
+\dim_new:N \l__tblr_cell_hcenter_dim
+\dim_new:N \l__tblr_cell_vcenter_dim
+\dim_new:N \l__tblr_table_height_dim
+\dim_new:N \l__tblr_table_depth_dim
+\dim_new:N \l__tblr_last_hline_height_dim
+\dim_new:N \l__tblr_last_vline_width_dim
+\box_new:N \l__tblr_tikz_node_box
 
-\NewTblrLibrary { tikzmark }
+\NewTblrLibrary { tikz }
   {
-    \__tblr_keys_define:nn { table / inner }
+    \keys_define:nn { tblr }
+    %\__tblr_keys_define:nn { table / inner }
         { 
-            tikzmark ~ prefix .code:n = {
-                \tl_set:Nn \l__tblr_tikzmark_prefix_tl { ##1 - } 
+            tikz ~ prefix .code:n = {
+                \tl_gset:Nn \g__tblr_tikz_prefix_tl { ##1 - } 
             } 
         }
+        
     \UseTblrLibrary { hook }
     \RequirePackage { tikz }
-    \usetikzlibrary { tikzmark }
-    \AddToHook { tabularray/cell/before } {
-        \hbox_set:Nn \l__tblr_tikzmark_box { 
-          \tikzmark{ \l__tblr_tikzmark_prefix_tl tblr - \arabic{colnum} - \arabic{rownum} } 
+    \tikzset {
+        tblr / cell ~ node / .style = {
+            rectangle ,
+            inner ~ sep = 0pt ,
+            draw = none ,
+            fill = none 
+        } ,
+        tblr / cell / .style = { } ,
+        tblr / table ~ node / .style = {
+            rectangle ,
+            inner ~ sep = 0pt ,
+            draw = none ,
+            fill = none 
+        } ,
+        tblr / table / .style = { } ,
+        tblr / overlay / .style = { }
+    }
+    
+    \NewDocumentEnvironment { tblrtikz } { } {
+      \begin{tikzpicture}[
+        remember ~ picture , 
+        overlay , 
+        name ~ prefix = \g__tblr_tikz_prefix_tl , 
+        tblr / overlay
+      ]
+    }{
+      \end{tikzpicture}
+    }
+    
+    \AddToHook { tabularray/cell/after } {
+        \dim_set:Nn \l__tblr_cell_inner_wd_dim { 
+            \l__tblr_x_tl + \l__tblr_y_tl + 
+            \l__tblr_cell_wd_dim
         }
-        \box_set_trim:Nnnnn \l__tblr_tikzmark_box 
-            { 0.5\rulewidth }
-            { 0.5\rulewidth }
-            { -0.5\rulewidth }
-            { -0.5\rulewidth }
-        \box_move_down:nn { \dim_eval:n { \l__tblr_row_dp_dim } }
-            { \box_use:N \l__tblr_tikzmark_box }
+        \hbox_set:Nn \l__tblr_tikz_node_box { 
+          \begin{tikzpicture}[remember ~ picture, overlay]
+            \node[
+                tblr / cell ~ node , 
+                tblr / cell ,
+                text ~ width = \l__tblr_cell_inner_wd_dim ,
+                text ~ height = \l__tblr_row_ht_dim , 
+                text ~ depth = \l__tblr_row_dp_dim
+            ] (
+                \g__tblr_tikz_prefix_tl 
+                tblr- 
+                \int_use:N \c@rownum - 
+                \int_use:N \c@colnum
+            ) at ( 0pt , 0pt ) { } ; 
+          \end{tikzpicture}
+        }
+        \dim_set:Nn \l__tblr_cell_hcenter_dim { 
+            0.5 \l__tblr_cell_inner_wd_dim 
+        }
+        \dim_set:Nn \l__tblr_cell_vcenter_dim {
+            0.5 \l__tblr_row_ht_dim -
+            0.5 \l__tblr_row_dp_dim 
+        }
+        \box_set_trim:Nnnnn \l__tblr_tikz_node_box  
+            { \l__tblr_cell_hcenter_dim }
+            { -\l__tblr_cell_vcenter_dim }
+            { -\l__tblr_cell_hcenter_dim } 
+            { \l__tblr_cell_vcenter_dim }
+        \box_use:N \l__tblr_tikz_node_box
+
+        \int_compare:nNnT { \c@rownum } = { \c@rowcount } {
+            \int_compare:nNnT { \c@colnum } = { \c@colcount } {
+                \__tblr_get_table_width:
+                \__tblr_get_table_height:
+                \__tblr_get_table_depth:
+                \dim_set:Nn \l__tblr_last_hline_height_dim {
+                    \__tblr_spec_item:nn { hline } { [ \int_eval:n { \c@rowcount + 1 } ] / @hline-height } 
+                }
+                \dim_set:Nn \l__tblr_last_vline_width_dim {
+                    \__tblr_spec_item:nn { vline } { [ \int_eval:n { \c@colcount + 1 } ] / @vline-width } 
+                }
+                \hbox_set:Nn \l__tblr_tikz_node_box { 
+                  \begin{tikzpicture}[remember ~ picture, overlay]
+                    \node[
+                        tblr / table ~ node , 
+                        tblr / table ,
+                        text ~ width = \tablewidth ,
+                        text ~ height = \l__tblr_table_height_dim ,
+                        text ~ depth = \l__tblr_table_depth_dim 
+                    ] (
+                        \g__tblr_tikz_prefix_tl 
+                        tblr
+                    ) at ( 0pt , 0pt ) { } ; 
+                  \end{tikzpicture}
+                }
+                \box_set_trim:Nnnnn \l__tblr_tikz_node_box { 
+                    0.5 \tablewidth +
+                    \l__tblr_last_vline_width_dim 
+                } { 
+                    -0.5 \l__tblr_table_height_dim +
+                    0.5 \l__tblr_table_depth_dim 
+                } { 
+                    -0.5 \tablewidth - 
+                    \l__tblr_last_vline_width_dim 
+                } { 
+                    0.5 \l__tblr_table_height_dim -
+                    0.5 \l__tblr_table_depth_dim  
+                }
+                \box_use:N \l__tblr_tikz_node_box
+            }
+        }
+    }
+  }
+
+\cs_new_protected:Npn \__tblr_get_table_height: 
+  {
+    \int_step_inline:nn { \c@rowcount - 1 } {
+        \dim_add:Nn \l__tblr_table_height_dim { 
+            \__tblr_valign_get_hline_total:n {##1} 
+        }
+        \dim_add:Nn \l__tblr_table_height_dim { 
+            \__tblr_valign_get_row_total:n {##1} 
+        }
+    }
+    \dim_add:Nn \l__tblr_table_height_dim { 
+        \__tblr_valign_get_hline_total:n { \int_use:N \c@rowcount } 
+    }
+    \dim_add:Nn \l__tblr_table_height_dim { 
+        \__tblr_valign_get_row_height:n { \int_use:N \c@rowcount }
+    }
+  }
+
+\cs_new_protected:Npn \__tblr_get_table_depth: 
+  {
+    \dim_set:Nn \l__tblr_table_depth_dim { 
+        \__tblr_valign_get_row_depth:n { \int_use:N \c@rowcount }
+    }
+    \dim_add:Nn \l__tblr_table_depth_dim { 
+        \__tblr_valign_get_hline_total:n { \int_eval:n { \c@rowcount + 1 } } 
     }
   }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -7550,12 +7550,12 @@
   {
     \keys_define:nn { tblr }
     %\__tblr_keys_define:nn { table / inner }
-        { 
+        {
             tikz ~ prefix .code:n = {
-                \tl_gset:Nn \g__tblr_tikz_prefix_tl { ##1 - } 
-            } 
+                \tl_gset:Nn \g__tblr_tikz_prefix_tl { ##1 - }
+            }
         }
-        
+
     \UseTblrLibrary { hook }
     \RequirePackage { tikz }
     \tikzset {
@@ -7563,62 +7563,62 @@
             rectangle ,
             inner ~ sep = 0pt ,
             draw = none ,
-            fill = none 
+            fill = none
         } ,
         tblr / cell / .style = { } ,
         tblr / table ~ node / .style = {
             rectangle ,
             inner ~ sep = 0pt ,
             draw = none ,
-            fill = none 
+            fill = none
         } ,
         tblr / table / .style = { } ,
         tblr / overlay / .style = { }
     }
-    
+
     \NewDocumentEnvironment { tblrtikz } { } {
       \begin{tikzpicture}[
-        remember ~ picture , 
-        overlay , 
-        name ~ prefix = \g__tblr_tikz_prefix_tl , 
+        remember ~ picture ,
+        overlay ,
+        name ~ prefix = \g__tblr_tikz_prefix_tl ,
         tblr / overlay
       ]
     }{
       \end{tikzpicture}
     }
-    
+
     \AddToHook { tabularray/cell/after } {
-        \dim_set:Nn \l__tblr_cell_inner_wd_dim { 
-            \l__tblr_x_tl + \l__tblr_y_tl + 
+        \dim_set:Nn \l__tblr_cell_inner_wd_dim {
+            \l__tblr_x_tl + \l__tblr_y_tl +
             \l__tblr_cell_wd_dim
         }
-        \hbox_set:Nn \l__tblr_tikz_node_box { 
+        \hbox_set:Nn \l__tblr_tikz_node_box {
           \begin{tikzpicture}[remember ~ picture, overlay]
             \node[
-                tblr / cell ~ node , 
+                tblr / cell ~ node ,
                 tblr / cell ,
                 text ~ width = \l__tblr_cell_inner_wd_dim ,
-                text ~ height = \l__tblr_row_ht_dim , 
+                text ~ height = \l__tblr_row_ht_dim ,
                 text ~ depth = \l__tblr_row_dp_dim
             ] (
-                \g__tblr_tikz_prefix_tl 
-                tblr- 
-                \int_use:N \c@rownum - 
+                \g__tblr_tikz_prefix_tl
+                tblr -
+                \int_use:N \c@rownum -
                 \int_use:N \c@colnum
-            ) at ( 0pt , 0pt ) { } ; 
+            ) at ( 0pt , 0pt ) { } ;
           \end{tikzpicture}
         }
-        \dim_set:Nn \l__tblr_cell_hcenter_dim { 
-            0.5 \l__tblr_cell_inner_wd_dim 
+        \dim_set:Nn \l__tblr_cell_hcenter_dim {
+            0.5 \l__tblr_cell_inner_wd_dim
         }
         \dim_set:Nn \l__tblr_cell_vcenter_dim {
             0.5 \l__tblr_row_ht_dim -
-            0.5 \l__tblr_row_dp_dim 
+            0.5 \l__tblr_row_dp_dim
         }
-        \box_set_trim:Nnnnn \l__tblr_tikz_node_box  
+        \box_set_trim:Nnnnn \l__tblr_tikz_node_box
             { \l__tblr_cell_hcenter_dim }
             { -\l__tblr_cell_vcenter_dim }
-            { -\l__tblr_cell_hcenter_dim } 
+            { -\l__tblr_cell_hcenter_dim }
             { \l__tblr_cell_vcenter_dim }
         \box_use:N \l__tblr_tikz_node_box
 
@@ -7628,37 +7628,37 @@
                 \__tblr_get_table_height:
                 \__tblr_get_table_depth:
                 \dim_set:Nn \l__tblr_last_hline_height_dim {
-                    \__tblr_spec_item:nn { hline } { [ \int_eval:n { \c@rowcount + 1 } ] / @hline-height } 
+                    \__tblr_spec_item:nn { hline } { [ \int_eval:n { \c@rowcount + 1 } ] / @hline-height }
                 }
                 \dim_set:Nn \l__tblr_last_vline_width_dim {
-                    \__tblr_spec_item:nn { vline } { [ \int_eval:n { \c@colcount + 1 } ] / @vline-width } 
+                    \__tblr_spec_item:nn { vline } { [ \int_eval:n { \c@colcount + 1 } ] / @vline-width }
                 }
-                \hbox_set:Nn \l__tblr_tikz_node_box { 
+                \hbox_set:Nn \l__tblr_tikz_node_box {
                   \begin{tikzpicture}[remember ~ picture, overlay]
                     \node[
-                        tblr / table ~ node , 
+                        tblr / table ~ node ,
                         tblr / table ,
                         text ~ width = \tablewidth ,
                         text ~ height = \l__tblr_table_height_dim ,
-                        text ~ depth = \l__tblr_table_depth_dim 
+                        text ~ depth = \l__tblr_table_depth_dim
                     ] (
-                        \g__tblr_tikz_prefix_tl 
+                        \g__tblr_tikz_prefix_tl
                         tblr
-                    ) at ( 0pt , 0pt ) { } ; 
+                    ) at ( 0pt , 0pt ) { } ;
                   \end{tikzpicture}
                 }
-                \box_set_trim:Nnnnn \l__tblr_tikz_node_box { 
+                \box_set_trim:Nnnnn \l__tblr_tikz_node_box {
                     0.5 \tablewidth +
-                    \l__tblr_last_vline_width_dim 
-                } { 
+                    \l__tblr_last_vline_width_dim
+                } {
                     -0.5 \l__tblr_table_height_dim +
-                    0.5 \l__tblr_table_depth_dim 
-                } { 
-                    -0.5 \tablewidth - 
-                    \l__tblr_last_vline_width_dim 
-                } { 
+                    0.5 \l__tblr_table_depth_dim
+                } {
+                    -0.5 \tablewidth -
+                    \l__tblr_last_vline_width_dim
+                } {
                     0.5 \l__tblr_table_height_dim -
-                    0.5 \l__tblr_table_depth_dim  
+                    0.5 \l__tblr_table_depth_dim
                 }
                 \box_use:N \l__tblr_tikz_node_box
             }
@@ -7666,30 +7666,30 @@
     }
   }
 
-\cs_new_protected:Npn \__tblr_get_table_height: 
+\cs_new_protected:Npn \__tblr_get_table_height:
   {
     \int_step_inline:nn { \c@rowcount - 1 } {
-        \dim_add:Nn \l__tblr_table_height_dim { 
-            \__tblr_valign_get_hline_total:n {##1} 
+        \dim_add:Nn \l__tblr_table_height_dim {
+            \__tblr_valign_get_hline_total:n {##1}
         }
-        \dim_add:Nn \l__tblr_table_height_dim { 
-            \__tblr_valign_get_row_total:n {##1} 
+        \dim_add:Nn \l__tblr_table_height_dim {
+            \__tblr_valign_get_row_total:n {##1}
         }
     }
-    \dim_add:Nn \l__tblr_table_height_dim { 
-        \__tblr_valign_get_hline_total:n { \int_use:N \c@rowcount } 
+    \dim_add:Nn \l__tblr_table_height_dim {
+        \__tblr_valign_get_hline_total:n { \int_use:N \c@rowcount }
     }
-    \dim_add:Nn \l__tblr_table_height_dim { 
+    \dim_add:Nn \l__tblr_table_height_dim {
         \__tblr_valign_get_row_height:n { \int_use:N \c@rowcount }
     }
   }
 
-\cs_new_protected:Npn \__tblr_get_table_depth: 
+\cs_new_protected:Npn \__tblr_get_table_depth:
   {
-    \dim_set:Nn \l__tblr_table_depth_dim { 
+    \dim_set:Nn \l__tblr_table_depth_dim {
         \__tblr_valign_get_row_depth:n { \int_use:N \c@rowcount }
     }
-    \dim_add:Nn \l__tblr_table_depth_dim { 
-        \__tblr_valign_get_hline_total:n { \int_eval:n { \c@rowcount + 1 } } 
+    \dim_add:Nn \l__tblr_table_depth_dim {
+        \__tblr_valign_get_hline_total:n { \int_eval:n { \c@rowcount + 1 } }
     }
   }


### PR DESCRIPTION
Issue #552 (which is sort of a sub-issue of issue #29 ) suggested to add a Ti*k*Z coordinate (also known as tikzmark) to the lower left corner of each cell in order to be able to refer to this coordinate later in the code.

I added a library named `tikzmark` which may be a first step in adding a `pgf` library to the package. It makes use of the `tabularray/cell/before` hook to add a `\tikzmark` at the lower left corner of every cell. It is possible to add a prefix to the name of the marks. 