### PR TITLE
Install `ppmcheckpdf` for regression test run on Win

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -30,6 +30,7 @@ jobs:
       uses: teatimeguest/setup-texlive-action@v3
       with:
         package-file: .github/workflows/texlive-package.txt
+        packages: ppmcheckpdf
         update-all-packages: true
     - name: Test tabularray with l3build
       run: |


### PR DESCRIPTION
67ca9c1 (support texlive 2022 (#480), 2024-12-11) removed `ppmcheckpdf` from latex/texlive package files, but it only added it to the regression test run on Ubuntu (defined in `regression.yml`). No `ppmcheckpdf` is now installed for the regression test run on Windows.

This results in failed job run (see [here](https://github.com/muzimuzhi/tabularray/actions/runs/12442145533/job/34740365035)) if `teatimeguest/setup-texlive-action@v3` failed to restore from an existing cache.
