### PR TITLE
Update action `teatimeguest/setup-texlive-action@v3`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install TeX Live
-      uses: teatimeguest/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v3
       with:
         version: ${{matrix.version}}
         package-file: .github/workflows/texlive-package.txt

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install TeX Live
-      uses: teatimeguest/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v3
       with:
         package-file: .github/workflows/texlive-package.txt
         packages: ppmcheckpdf
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install TeX Live
-      uses: teatimeguest/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v3
       with:
         package-file: .github/workflows/texlive-package.txt
         packages: ppmcheckpdf


### PR DESCRIPTION
The original author had deleted their GitHub account. A drop-in replacement is now provided by TeX-Live org.