### PR TITLE
use \vbox_center:n instead of \tex_vcenter:D, and box it outside math…

### DIFF
--- a/tabularray.sty
+++ b/tabularray.sty
@@ -6993,13 +6993,13 @@
 
 %% We box the vertical box outside of math for correct alignment of
 %% the rules in LuaTeX (the directions inside math can switch, see #351)
-\cs_new_protected:Npn \__tblr_get_vcenter_box:N #1
+\cs_set_protected:Npn \__tblr_get_vcenter_box:N #1
   {
     \hbox:n
       {
-        \vbox_set:Nn \l_tmpa_box { \vbox_center:n { \vbox_unpack_drop:N #1 } }
+        \vbox_set:Nn \l_tmpa_box { \vbox:n { \vbox_unpack_drop:N #1 } }
         $ \m@th \l__tblr_delim_left_tl
-        \box_use_drop:N \l_tmpa_box
+        \tex_vcenter:D { \vbox_unpack_drop:N \l_tmpa_box }
         \l__tblr_delim_right_tl $
       }
   }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -6991,15 +6991,14 @@
       }
   }
 
-%% We box the vertical box outside of math for correct alignment of
+%% Use the vertical box from the outside of math for correct alignment of
 %% the rules in LuaTeX (the directions inside math can switch, see #351)
-\cs_set_protected:Npn \__tblr_get_vcenter_box:N #1
+\cs_new_protected:Npn \__tblr_get_vcenter_box:N #1
   {
     \hbox:n
       {
-        \vbox_set:Nn \l_tmpa_box { \vbox:n { \vbox_unpack_drop:N #1 } }
         $ \m@th \l__tblr_delim_left_tl
-        \tex_vcenter:D { \vbox_unpack_drop:N \l_tmpa_box }
+        \tex_vcenter:D { \box_use_drop:N #1 }
         \l__tblr_delim_right_tl $
       }
   }

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -6991,12 +6991,15 @@
       }
   }
 
+%% We box the vertical box outside of math for correct alignment of
+%% the rules in LuaTeX (the directions inside math can switch, see #351)
 \cs_new_protected:Npn \__tblr_get_vcenter_box:N #1
   {
     \hbox:n
       {
+        \vbox_set:Nn \l_tmpa_box { \vbox_center:n { \vbox_unpack_drop:N #1 } }
         $ \m@th \l__tblr_delim_left_tl
-        \tex_vcenter:D { \vbox_unpack_drop:N #1 }
+        \box_use_drop:N \l_tmpa_box
         \l__tblr_delim_right_tl $
       }
   }


### PR DESCRIPTION
… (fixes #351)

See the explanation in https://github.com/TeXackers/tabularray/issues/351#issuecomment-4222858037