### PR TITLE
feat: capcont-text

### DIFF
--- a/tabularray.sty
+++ b/tabularray.sty
@@ -6010,6 +6010,18 @@
   }
 \SetTblrTemplate { caption } { normal }
 
+\DeclareTblrTemplate { capcont-pre } { normal }
+  {
+    \UseTblrTemplate { conthead-pre } { default }
+  }
+\SetTblrTemplate { capcont-pre } { normal }
+
+\DeclareTblrTemplate { capcont-text } { normal }
+  {
+    \UseTblrTemplate { conthead-text } { default }
+  }
+\SetTblrTemplate { capcont-text } { normal }
+
 \DeclareTblrTemplate { capcont } { empty } { }
 \DeclareTblrTemplate { capcont } { plain }
   {
@@ -6018,8 +6030,8 @@
         \UseTblrTemplate { caption-tag } { default }
         \UseTblrTemplate { caption-sep } { default }
         \UseTblrTemplate { caption-text } { default }
-        \UseTblrTemplate { conthead-pre } { default }
-        \UseTblrTemplate { conthead-text } { default }
+        \UseTblrTemplate { capcont-pre } { default }
+        \UseTblrTemplate { capcont-text } { default }
       }
     \dim_compare:nNnTF { \box_wd:N \l__tblr_caption_box } > { \hsize }
       {
@@ -6040,8 +6052,8 @@
         \UseTblrTemplate { caption-tag } { default }
         \UseTblrTemplate { caption-sep } { default }
         \UseTblrTemplate { caption-text } { default }
-        \UseTblrTemplate { conthead-pre } { default }
-        \UseTblrTemplate { conthead-text } { default }
+        \UseTblrTemplate { capcont-pre } { default }
+        \UseTblrTemplate { capcont-text } { default }
       }
     \dim_compare:nNnTF { \box_wd:N \l__tblr_caption_box } > { \hsize }
       {
@@ -6074,8 +6086,8 @@
     \UseTblrTemplate { caption-tag } { default }
     \UseTblrTemplate { caption-sep } { default }
     \UseTblrTemplate { caption-text } { default }
-    \UseTblrTemplate { conthead-pre } { default }
-    \UseTblrTemplate { conthead-text } { default }
+    \UseTblrTemplate { capcont-pre } { default }
+    \UseTblrTemplate { capcont-text } { default }
     \par
   }
 \SetTblrTemplate { capcont} { normal }


### PR DESCRIPTION
This adds a new template `capcont-text` (and `capcont-pre`) so that `capcont` is no longer hard-coded to use `conthead-*` templates. This is useful when one wants to format long tables with captions in the footer rather than the header, where otherwise one currently has to either redefine `capcont` to use `contfoot-text` or swap the meaning of `conthead-text` and `contfoot-text`, which is confusing.

I haven't documented anything in the manual yet, but am happy to do so if others agree with the idea itself; I'm also very open to other suggestions to achieve the desired outcome in a clean manner!

Essentially I would like to be able to do this:
```latex
% simply change `capcont-text` to use footer text instead of header text
\DeclareTblrTemplate{capcont-text}{default}{\UseTblrTemplate{contfoot-text}{default}}
\DeclareTblrTemplate{firsthead}{default}{}
% headers then use standard `conthead` template
\DeclareTblrTemplate{middlehead,lasthead}{default}{\UseTblrTemplate{conthead}{default}}
% and `capcont` is used the footer
\DeclareTblrTemplate{firstfoot,middlefoot}{default}{\UseTblrTemplate{capcont}{default}}
\DeclareTblrTemplate{lastfoot}{default}{
  \UseTblrTemplate{caption}{default}
  \UseTblrTemplate{note}{default}
  \UseTblrTemplate{remark}{default}
}
```

instead of either this:
```latex
% swap the header and footer text
\DeclareTblrTemplate{conthead-text}{default}{\tblrcontfootname}
\DeclareTblrTemplate{contfoot-text}{default}{\tblrcontheadname}
\DeclareTblrTemplate{firsthead}{default}{}
% and now the headers use the `contfoot` template, which is semantically confusing
\DeclareTblrTemplate{middlehead,lasthead}{default}{\UseTblrTemplate{contfoot}{default}}
% the rest is the same
\DeclareTblrTemplate{firstfoot,middlefoot}{default}{\UseTblrTemplate{capcont}{default}}
\DeclareTblrTemplate{lastfoot}{default}{
  \UseTblrTemplate{caption}{default}
  \UseTblrTemplate{note}{default}
  \UseTblrTemplate{remark}{default}
}
```

or having to redefine the entire `capcont` template, which is annoying for such a simple switch if one wants to preserve the full `normal` template behaviour:
<details><summary>LaTeX code</summary>

```latex
\ExplSyntaxOn
% have to copy-and-paste the whole definition from `tabularray.sty`
\DeclareTblrTemplate { capcont } { normal }
  {
    \hbox_set:Nn \l__tblr_caption_box
      {
        \UseTblrTemplate { caption-tag } { default }
        \UseTblrTemplate { caption-sep } { default }
        \UseTblrTemplate { caption-text } { default }
        \UseTblrTemplate { conthead-pre } { default }
        \UseTblrTemplate { contfoot-text } { default } % just to change `conthead-text` to `contfoot-text`
      }
    \dim_compare:nNnTF { \box_wd:N \l__tblr_caption_box } > { \hsize }
      {
        \UseTblrAlign { capcont }
        \UseTblrIndent { capcont }
        \hbox_set:Nn \l__tblr_caption_left_box
          {
            \UseTblrTemplate { caption-tag } { default }
            \UseTblrTemplate { caption-sep } { default }
          }
        \hangindent = \box_wd:N \l__tblr_caption_left_box
        \hangafter = 1
        \UseTblrHang { capcont }
        \leavevmode
        \hbox_unpack:N \l__tblr_caption_box
        \par
      }
      {
        \centering
        \makebox [\hsize] [c] { \box_use:N \l__tblr_caption_box }
        \par
      }
  }
\ExplSyntaxOff
% and the rest is the same as the first example, where the above was simplified to one line
\DeclareTblrTemplate{firsthead}{default}{}
\DeclareTblrTemplate{middlehead,lasthead}{default}{\UseTblrTemplate{conthead}{default}}
\DeclareTblrTemplate{firstfoot,middlefoot}{default}{\UseTblrTemplate{capcont}{default}}
\DeclareTblrTemplate{lastfoot}{default}{
  \UseTblrTemplate{caption}{default}
  \UseTblrTemplate{note}{default}
  \UseTblrTemplate{remark}{default}
}
```
</details>